### PR TITLE
Stop explicitly importing a foreman dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ default: install
 
 install: Gemfile
 	bundle install
-	gem install dotenv-deployment
 	gem install foreman
 
 load-data:


### PR DESCRIPTION
The issue there had been with `gem install foreman` not fetching dependencies seems to have resolved itself – I just tried a clean checkout and VM and was able to install everything successfully. This explicit `gem install` is no longer necessary.
