### PR TITLE
Adds Skip link 

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -47,6 +47,7 @@
 	</head>
 	
 	<body>
+		<a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 		<div id="wrap">
 
 			<!-- Fixed navbar -->
@@ -138,9 +139,9 @@
 			
 
 			<!-- Begin page content -->
-			<div class="container-fluid">
 				
 				
+			<div id="content" class="container-fluid">
 				<%= yield %>
 				
 				

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -140,6 +140,8 @@
 
 			<!-- Begin page content -->
 			<div id="content" class="container-fluid">
+
+
 				<%= yield %>
 				
 				

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -139,8 +139,6 @@
 			
 
 			<!-- Begin page content -->
-				
-				
 			<div id="content" class="container-fluid">
 				<%= yield %>
 				


### PR DESCRIPTION
Adds a link to allow visitors navigating by screen reader/keyboard to
skip focus to the content area.

Note that in order to make this fully compatible with the WCAG
recommendation Bootstrap should be upgraded to v3.2.0, where Bootstrap
adds hide/show on focus via the .sr-only-focusable class.